### PR TITLE
Attempt at fixing plugin crash

### DIFF
--- a/csgo/addons/sourcemod/scripting/goonpug.sp
+++ b/csgo/addons/sourcemod/scripting/goonpug.sp
@@ -1130,7 +1130,7 @@ public Action:Event_PlayerDisconnect(
         {
             if (ClientIsReady(client))
             {
-                ChangeMatchState(MS_PICK_CAPTAINS);
+                ChangeMatchState(MS_WARMUP);
                 PrintToChatAll("[GP] Will restart picking teams when we have enough players...");
                 StartReadyUp(false);
             }


### PR DESCRIPTION
Attempting to fix plugin crashing when a captain leaves during picking. Now when a player disconnects during picking, it just sends the plugin back to warm-up state. This isn't the original intended behavior to avoid re-voting for maps. However, an admin currently has to restart the plugin anyway so this way the plugin should avoid crashing with the same functional behavior.
