### PR TITLE
Replace sv_alltalk (deprecated) with sv_talk_enemy_dead and sv_talk_enemy_living

### DIFF
--- a/csgo/cfg/goonpug_pug.cfg
+++ b/csgo/cfg/goonpug_pug.cfg
@@ -7,7 +7,8 @@ ammo_grenade_limit_total 4
 sv_accelerate 5.6               //( def. "10" ) client notify replicated 
 sv_friction 4.8                 // World friction.
 
-sv_alltalk 0                    // Players can hear all other players' voice communication, no team restrictions
+sv_talk_enemy_living 0          // Living players can hear all living enemy communication (voice, chat)
+sv_talk_enemy_dead 0            // Dead players can hear all dead enemy communication (voice, chat)
 sv_full_alltalk 0               // Any player (including Spectator team) can speak to any other player
 sv_deadtalk 1                   // Dead players can speak (voice, text) to the living
 

--- a/csgo/cfg/goonpug_warmup.cfg
+++ b/csgo/cfg/goonpug_warmup.cfg
@@ -1,6 +1,7 @@
 // GoonPUG Warmup Config
 //
-sv_alltalk 1                    // Players can hear all other players' voice communication, no team restrictions
+sv_talk_enemy_living 1          // Living players can hear all living enemy communication (voice, chat)
+sv_talk_enemy_dead 1            // Dead players can hear all dead enemy communication (voice, chat)
 sv_full_alltalk 1               // Any player (including Spectator team) can speak to any other player
 sv_deadtalk 1                   // Dead players can speak (voice, text) to the living
 


### PR DESCRIPTION
This might fix the alltalk being broken in warmup team picking and pre-rounds. Not tested.